### PR TITLE
Fix dep versions to allow updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ An implementation of SSL streams for async-std backed by OpenSSL. Based on sfack
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false }
-openssl = "0.10.32"
+openssl = "0.10"
 openssl-sys = "0.9"
-async-std = "1.9.0"
+async-std = "1.9"
 async-dup = "1.2"
 
 [dev-dependencies]
-async-std = { version = "1.9.0", features = ["attributes"] }
+async-std = { version = "1.9", features = ["attributes"] }


### PR DESCRIPTION
Shouldn't specify exact versions as this taints downstream consumers to lock them to these versions.
